### PR TITLE
FIX: Update CircleCI MySQL image to next-generation image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     shell: /bin/bash --login
     docker:
       - image: silverstripe/dashboard-ci:latest
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu
           - MYSQL_DATABASE=circle_test


### PR DESCRIPTION
As per CirleCI's recommendation we should update the MySQL image to use a next-generation image as the old one will be deprecated. Context: https://circleci.com/docs/2.0/circleci-images/